### PR TITLE
fix: avoid message mistakenly appended

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,15 +2,19 @@ name: CI
 
 on:
   workflow_dispatch:
-  pull_request:
+  push:
     branches:
       - main
     paths-ignore:
       - 'docs/**'
       - '**.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 jobs:
-  statics:
+  CI:
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
@@ -18,7 +22,15 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.17
-      - run: |
+      - name: Install tools
+        run: |
           make install-tools
-          make check
+      - name: Lint
+        run: |
+          make lint
+      - name: Unit test
+        run: |
           make test
+      - name: Check license
+        run: |
+          make check-license

--- a/Makefile
+++ b/Makefile
@@ -8,32 +8,24 @@ SHELL := env PATH='$(PATH)' GOBIN='$(GO_TOOLS_BIN_PATH)' $(shell which bash)
 install-tools:
 	@mkdir -p $(GO_TOOLS_BIN_PATH)
 	@(which golangci-lint && golangci-lint version | grep '1.51') >/dev/null 2>&1 || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_TOOLS_BIN_PATH) v1.51.2
-	@go install github.com/AlekSi/gocov-xml@v1.1.0
-	@go install github.com/axw/gocov/gocov@v1.1.0
 	@go install github.com/mgechev/revive@v1.2.5
 	@go install golang.org/x/tools/cmd/goimports@latest
-	@go install gotest.tools/gotestsum@latest
 
 PKG := github.com/CeresDB/ceresdb-client-go
 PACKAGES := $(shell go list ./... | tail -n +2)
 PACKAGE_DIRECTORIES := $(subst $(PKG)/,,$(PACKAGES))
 
-check: install-tools
-	@ echo "check license ..."
-	@ make check-license
-	@ echo "gofmt ..."
-	@ gofmt -s -l -d $(PACKAGE_DIRECTORIES) 2>&1 | awk '{ print } END { if (NR > 0) { exit 1 } }'
-	@ echo "golangci-lint ..."
-	@ golangci-lint run $(PACKAGE_DIRECTORIES)
-	@ echo "revive ..."
-	@ revive -formatter friendly -config revive.toml $(PACKAGES)
+lint:
+	golangci-lint run -v
+	revive -formatter friendly -config revive.toml ./...
 
 check-license:
-	@ sh ./tools/check-license.sh
+	sh ./tools/check-license.sh
 
-test: install-tools
-	@ echo "go test ..."
-	@ go test -timeout 5m -race -cover $(PACKAGES)
+test:
+	go test -timeout 5m -race -cover ./...
 
 tidy:
 	go mod tidy
+
+.PHONY: test check tidy check-license install-tools

--- a/ceresdb/client_impl.go
+++ b/ceresdb/client_impl.go
@@ -28,7 +28,7 @@ func newClient(endpoint string, routeMode RouteMode, opts options) (Client, erro
 
 func shouldClearRoute(err error) bool {
 	if err != nil {
-		if ceresdbErr, ok := err.(*CeresdbError); ok && ceresdbErr.ShouldClearRoute() {
+		if ceresdbErr, ok := err.(*Error); ok && ceresdbErr.ShouldClearRoute() {
 			return true
 		} else if strings.Contains(err.Error(), "connection error") {
 			// TODO: Find a better way to check if err means remote endpoint is down.

--- a/ceresdb/client_impl.go
+++ b/ceresdb/client_impl.go
@@ -102,12 +102,13 @@ func (c *clientImpl) Write(ctx context.Context, req WriteRequest) (WriteResponse
 			}
 
 			// Only return first error message now.
-			if ret.Message != "" {
+			if ret.Message == "" {
 				ret.Message = err.Error()
 			}
 			ret = combineWriteResponse(ret, WriteResponse{Failed: uint32(len(points))})
 			continue
 		}
+
 		ret = combineWriteResponse(ret, response)
 	}
 

--- a/ceresdb/code.go
+++ b/ceresdb/code.go
@@ -29,20 +29,20 @@ const (
 	codeFlowControl  = 503
 )
 
-type CeresdbError struct {
+type Error struct {
 	Code uint32
 	Err  string
 }
 
-func (e *CeresdbError) Error() string {
+func (e *Error) Error() string {
 	return fmt.Sprintf("ceresdb rpc failed, code:%d, err:%s", e.Code, e.Err)
 }
 
 // TODO: may retry in sdk while code is 302 or 310
-func (e *CeresdbError) ShouldRetry() bool {
+func (e *Error) ShouldRetry() bool {
 	return false
 }
 
-func (e *CeresdbError) ShouldClearRoute() bool {
+func (e *Error) ShouldClearRoute() bool {
 	return e.Code == codeInvalidRoute
 }

--- a/ceresdb/rpc.go
+++ b/ceresdb/rpc.go
@@ -52,14 +52,14 @@ func (c *rpcClient) SQLQuery(ctx context.Context, endpoint string, req SQLQueryR
 	}
 
 	if queryResponse.Header == nil {
-		return SQLQueryResponse{}, &CeresdbError{
+		return SQLQueryResponse{}, &Error{
 			Code: codeInternal,
 			Err:  ErrResponseHeaderMiss.Error(),
 		}
 	}
 
 	if queryResponse.Header.Code != codeSuccess {
-		return SQLQueryResponse{}, &CeresdbError{
+		return SQLQueryResponse{}, &Error{
 			Code: queryResponse.Header.Code,
 			Err:  queryResponse.Header.Error,
 		}
@@ -105,14 +105,14 @@ func (c *rpcClient) Write(ctx context.Context, endpoint string, reqCtx RequestCo
 	}
 
 	if writeResponse.Header == nil {
-		return WriteResponse{}, &CeresdbError{
+		return WriteResponse{}, &Error{
 			Code: codeInternal,
 			Err:  ErrResponseHeaderMiss.Error(),
 		}
 	}
 
 	if writeResponse.Header.Code != codeSuccess {
-		return WriteResponse{}, &CeresdbError{
+		return WriteResponse{}, &Error{
 			Code: writeResponse.Header.Code,
 			Err:  writeResponse.Header.Error,
 		}
@@ -143,14 +143,14 @@ func (c *rpcClient) Route(endpoint string, reqCtx RequestContext, tables []strin
 	}
 
 	if routeResponse.Header == nil {
-		return nil, &CeresdbError{
+		return nil, &Error{
 			Code: codeInternal,
 			Err:  ErrResponseHeaderMiss.Error(),
 		}
 	}
 
 	if routeResponse.Header.Code != codeSuccess {
-		return nil, &CeresdbError{
+		return nil, &Error{
 			Code: routeResponse.Header.Code,
 			Err:  routeResponse.Header.Error,
 		}


### PR DESCRIPTION
## Rationale
Current implementation will append multiple error message together.

## Detailed Changes
- Fix broken CI, rename `CeresdbError` to `Error`.
- Only append error message when old message is empty. 

## Test Plan
CI