### PR TITLE
chore: rename ceresdb to horaedb

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for CeresDB
+about: Suggest an idea for HoraeDB
 labels: enhancement
 ---
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask question about CeresDB
+about: Ask question about HoraeDB
 labels: question
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install-tools:
 	@go install github.com/mgechev/revive@v1.2.5
 	@go install golang.org/x/tools/cmd/goimports@latest
 
-PKG := github.com/CeresDB/ceresdb-client-go
+PKG := github.com/CeresDB/horaedb-client-go
 PACKAGES := $(shell go list ./... | tail -n +2)
 PACKAGE_DIRECTORIES := $(subst $(PKG)/,,$(PACKAGES))
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# [CeresDB](https://github.com/CeresDB/ceresdb) Golang Client
+# [HoraeDB](https://github.com/CeresDB/horaedb) Golang Client
 
-[![CI](https://github.com/CeresDB/ceresdb-client-go/actions/workflows/CI.yml/badge.svg)](https://github.com/CeresDB/ceresdb-client-go/actions/workflows/CI.yml)
-[![Go Reference](https://pkg.go.dev/badge/github.com/CeresDB/ceresdb-client-go.svg)](https://pkg.go.dev/github.com/CeresDB/ceresdb-client-go)
-[![Go Report Card](https://goreportcard.com/badge/github.com/CeresDB/ceresdb-client-go)](https://goreportcard.com/report/github.com/CeresDB/ceresdb-client-go)
+[![CI](https://github.com/CeresDB/horaedb-client-go/actions/workflows/CI.yml/badge.svg)](https://github.com/CeresDB/horaedb-client-go/actions/workflows/CI.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/CeresDB/horaedb-client-go.svg)](https://pkg.go.dev/github.com/CeresDB/horaedb-client-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/CeresDB/horaedb-client-go)](https://goreportcard.com/report/github.com/CeresDB/horaedb-client-go)
 
 ## Introduction
 
-Golang client for [CeresDB](https://github.com/CeresDB/ceresdb).
+Golang client for [HoraeDB](https://github.com/CeresDB/horaedb).
 
 ## Support features
 - DDL, such as create/alter table
@@ -14,12 +14,12 @@ Golang client for [CeresDB](https://github.com/CeresDB/ceresdb).
 
 ## How To Use
 
-Please refer [Golang SDK docs](https://docs.ceresdb.io/en/sdk/go.html).
+Please refer [Golang SDK docs](https://ceresdb.github.io/docs/en/sdk/go.html).
 
 ## License
 Under [Apache License 2.0](./LICENSE).
 
 ## Community and support
 - Join the user group on [Slack](https://join.slack.com/t/ceresdbcommunity/shared_invite/zt-1au1ihbdy-5huC9J9s2462yBMIWmerTw)
-- Join the user group on WeChat [WeChat QR code](https://github.com/CeresDB/assets/blob/main/WeChatQRCode.jpg)
+- Join the user group on WeChat [WeChat QR code](https://github.com/CeresDB/community/blob/main/communication/wechat/group_qrcode.png)
 - Join the user group on DingTalk: 44602802


### PR DESCRIPTION
## Rationale
Rename ceresdb to horaedb in the Readme.

## Detailed Changes
Rename ceresdb to horaedb in the Readme.

## Test Plan
CI.